### PR TITLE
remove UpperBounds dependency enforcer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,24 +215,73 @@
       <artifactId>script-security</artifactId>
       <version>1.54</version>
     </dependency>
-    <!-- not sure if this makes any difference but attempting to fix enforcer errors-->
-    <!-- TODO rather use dependencyManagement if necessary -->
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.10.1</version>
-    </dependency>
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
-      <version>4.1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>2.9.0</version>
-    </dependency>
   </dependencies>
+
+  <!--
+    This is to just remove the UpperBounds rule
+    This rule is covered by the tests that actually start jenkins and look for plugin start failures.
+    This needs to be kept in sync with the parent.
+  -->
+  <build>
+    <plugins>
+       <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>display-info</id>
+            <configuration>
+              <rules combine.self="override">
+                <requireMavenVersion>
+                  <version>[3.3.1,)</version>
+                  <message>3.3.1 required to at least look at .mvn/ if it exists.</message>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[1.8.0,)</version>
+                </requireJavaVersion>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.8</maxJdkVersion>
+                  <ignoredScopes>
+                    <ignoredScope>test</ignoredScope>
+                  </ignoredScopes>
+                  <excludes>
+                    <exclude>org.jenkins-ci.main:jenkins-core</exclude>
+                    <exclude>org.jenkins-ci.main:cli</exclude>
+                    <exclude>org.jenkins-ci.main:jenkins-test-harness</exclude>
+                    <exclude>org.jenkins-ci.main:remoting</exclude>
+                    <exclude>org.kohsuke.stapler:stapler</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jrebel</exclude>
+                    <exclude>org.jenkins-ci:task-reactor</exclude>
+                    <exclude>com.google.code.findbugs:annotations</exclude>
+                  </excludes>
+                </enforceBytecodeVersion>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>javax.servlet:servlet-api</exclude>
+                    <exclude>org.sonatype.sisu:sisu-guice</exclude>
+                    <exclude>log4j:log4j:*:jar:compile</exclude>
+                    <exclude>log4j:log4j:*:jar:runtime</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.1</version>
+            <scope>compile</scope>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
 
   <licenses>
     <license>


### PR DESCRIPTION
remove the UpperBounds dependency enforcer rule.

The rule was giving lots of false positives in this context.  

Whilst there is still some value in the results the amount of false positives mean that it is like wading through mud to fix them.

What we really care about is the requirements of plugins to make sure their dependencies on other plugins is fixed - and this can be seen in the logs when starting up (as a specific plugin will be flagged as failing to start).

This additional check of the logs may need to be performed, as it may well be that the actual build test does not excersize all of the plugins, hence this is WIP until that test has been done or someone that knows the test that gets excersized as part of the build covers this scenario.

/cc @garethjevans 